### PR TITLE
Fix linter errors and warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,12 +21,13 @@
     "comma-dangle": [ 1, "never" ],
     "eqeqeq": [ 2, "smart" ],
     "jsx-quotes": [ 1, "prefer-double" ],
+    "no-console": 0,
     "no-unused-vars": 0,
     "object-curly-spacing": [ 1, "always" ],
     "quotes": [ 1, "single", "avoid-escape" ],
     "react/jsx-space-before-closing": [ 1, "never" ],
     "react/no-did-mount-set-state": 0,
-    "react/prop-types": 1,
+    "react/prop-types": 0,
     "semi": [ 1, "never" ],
     "space-before-blocks": [ 1, "always" ]
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "parser": "babel-eslint",
   "env": {
     "browser": true,

--- a/subjects/HigherOrderComponents/solution.js
+++ b/subjects/HigherOrderComponents/solution.js
@@ -10,6 +10,7 @@ import ReactDOM from 'react-dom'
 
 const withMousePosition = (Component) => {
   return class extends React.Component {
+    displayName = 'ComponentWithMousePosition'
     state = { x: 0, y: 0 }
 
     handleMouseMove = (event) => {

--- a/subjects/Select/exercise.js
+++ b/subjects/Select/exercise.js
@@ -44,7 +44,7 @@ class App extends React.Component {
   }
 
   setToMintChutney = () => {
-   this.setState({selectValue: 'mint-chutney'})
+   this.setState({ selectValue: 'mint-chutney' })
   }
 
   render() {


### PR DESCRIPTION
Hey :wave:

Opened the training material and my editor started warning me about linter errors... so I thought I'd fix them.

Some judgement calls in here:

* Added `"no-console": 0,` because logging seems like a good thing to be allowed to do in exercises
* There were 65 missing propTypes, which seemed like they might distract from the point of the exercises if I added them so I disabled the `"react/prop-types"` rule
* I'd usually use `WithMousePosition(${Component.displayName || Component.name})` as the `displayName` for the HOC but went with a simple string to keep things focused on the point of the exercise

Also updated `.eslintrc => .eslintrc.js` because [eslintrc is deprecated](http://eslint.org/docs/user-guide/configuring#configuration-file-formats)

Happy to make any changes (including adding prop types) if you want.